### PR TITLE
Changed instructions for converting image to zarr

### DIFF
--- a/notebooks/Solved_Zarr_and_Dask_for_large-scale_imaging-Part-2.ipynb
+++ b/notebooks/Solved_Zarr_and_Dask_for_large-scale_imaging-Part-2.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a terminal (e.g. from the Launcher) and use the following command:\n",
+    "You can convert an image file to OME-Zarr format using [`bioformats2raw`](https://github.com/glencoesoftware/bioformats2raw).\n",
     "\n",
     "```\n",
     "bioformats2raw CMU-1_Crop.ome.tif CMU-1_Crop.ome.zarr --use-existing-resolutions -p\n",

--- a/notebooks/Zarr_and_Dask_for_large-scale_imaging-Part-2.ipynb
+++ b/notebooks/Zarr_and_Dask_for_large-scale_imaging-Part-2.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open a terminal (e.g. from the Launcher) and use the following command:\n",
+    "You can convert an image file to OME-Zarr format using [`bioformats2raw`](https://github.com/glencoesoftware/bioformats2raw).\n",
     "\n",
     "```\n",
     "bioformats2raw CMU-1_Crop.ome.tif CMU-1_Crop.ome.zarr --use-existing-resolutions -p\n",


### PR DESCRIPTION
Removed the operation of converting the image during the tutorial.

That command is still shown for reference.